### PR TITLE
chore: bump version to 0.1.2 for release update

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.1
+current_version = 0.1.2
 commit = True
 tag = True
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.2
+current_version = 0.1.3
 commit = True
 tag = True
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.3
+current_version = 0.1.2
 commit = True
 tag = True
 

--- a/api_bridge/__init__.py
+++ b/api_bridge/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 print("api_bridge package is being imported")
 from .core import APIBridge

--- a/api_bridge/__init__.py
+++ b/api_bridge/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.1.3"
+__version__ = "0.1.2"
 print("api_bridge package is being imported")
 from .core import APIBridge

--- a/api_bridge/__init__.py
+++ b/api_bridge/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 print("api_bridge package is being imported")
 from .core import APIBridge

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="smart_api_bridge",
-    version="0.1.1",
+    version="0.1.2",
     description="A FastAPI-based CRUD API generator for MySQL databases",
     author="Venkat.R",
     author_email="ai.venkat.r@gmail.com",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="smart_api_bridge",
-    version="0.1.2",
+    version="0.1.3",
     description="A FastAPI-based CRUD API generator for MySQL databases",
     author="Venkat.R",
     author_email="ai.venkat.r@gmail.com",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="smart_api_bridge",
-    version="0.1.3",
+    version="0.1.2",
     description="A FastAPI-based CRUD API generator for MySQL databases",
     author="Venkat.R",
     author_email="ai.venkat.r@gmail.com",


### PR DESCRIPTION
This update increments the version to 0.1.2 to reflect recent changes and improvements. Ensures proper versioning for tracking updates and maintaining consistency across deployments.